### PR TITLE
Replace bitnami image references with bitnamilegacy

### DIFF
--- a/sonarqube-postgresql/sonarqube-postgresql.yaml
+++ b/sonarqube-postgresql/sonarqube-postgresql.yaml
@@ -83,7 +83,7 @@ nginx:
       container: nginx-reverse-proxy
   containers:
     nginx-reverse-proxy:
-      image: docker.io/bitnami/nginx
+      image: docker.io/bitnamilegacy/nginx
       image-tag: <- $nginx-image-tag default("latest")
       cap-add:
         - CAP_NET_BIND_SERVICE

--- a/sonarqube-with-h2/sonarqube-with-h2.yaml
+++ b/sonarqube-with-h2/sonarqube-with-h2.yaml
@@ -39,7 +39,7 @@ nginx:
       container: nginx-reverse-proxy
   containers:
     nginx-reverse-proxy:
-      image: docker.io/bitnami/nginx
+      image: docker.io/bitnamilegacy/nginx
       image-tag: <- $nginx-image
       cap-add:
         - CAP_NET_BIND_SERVICE


### PR DESCRIPTION
This PR replaces 'image: docker.io/bitnami/' and 'image: bitnami/' with their 'bitnamilegacy' equivalents, as per organization migration.